### PR TITLE
hotfix: migrate API base URL from Railway to Vercel

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,7 +1,7 @@
 import { IClassesData } from "../types/dataClasses.interface";
 import { IClassItem } from "../components/classItem/classItem.Interface";
 
-const API_BASE_URL = "https://que-aula-api.up.railway.app";
+const API_BASE_URL = "https://que-aula-api.vercel.app";
 
 interface IHealthCheck {
   message: string;


### PR DESCRIPTION
## 🚨 Hotfix: API Migration Railway → Vercel

### Problem
- API hosted on Railway is no longer accessible
- Application breaking due to failed API calls

### Solution
- Updated `API_BASE_URL` in `/src/services/api.ts`
- Migrated from Railway to Vercel hosting

### Testing
- [x] Build successful
- [x] API endpoints responding correctly
- [x] No breaking changes to interface

### Impact
- **Critical**: Restores application functionality
- **Zero downtime**: No interface changes required