### PR TITLE
Fix: Comment coverage on PR step error

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -43,7 +43,6 @@ jobs:
             echo "Please update your branch: git pull origin develop"
           fi
           
-          # Verificar conflitos
           if git merge-tree $(git merge-base HEAD origin/develop) HEAD origin/develop | grep -q '<<<<<<<'; then
             echo "Branch has merge conflicts with develop"
             echo "Please resolve conflicts before merging"


### PR DESCRIPTION
## 🐛 Problem
CI pipeline failing with "Resource not accessible by integration" when trying to comment on PRs from forks.

## 🔧 Fix
- **Added GitHub Actions permissions** (`pull-requests: write`, `issues: write`)
- **Split PR comments** into internal vs external PRs:
  - **Internal PRs**: Posts coverage comment 
  - **External PRs**: Logs coverage data (avoids permission error)